### PR TITLE
New syntax

### DIFF
--- a/aptget.py
+++ b/aptget.py
@@ -60,7 +60,7 @@ class AptGet(dotbot.Plugin):
             for pkg_name in packages:
                 cleaned_dict['packages'][pkg_name] = False
         elif isinstance(packages, dict):
-                new_syntax = False
+            new_syntax = False
             for key, value in packages.items():
                 if key == "packages" and isinstance(value, list):
                     continue

--- a/aptget.py
+++ b/aptget.py
@@ -60,15 +60,33 @@ class AptGet(dotbot.Plugin):
             for pkg_name in packages:
                 cleaned_dict['packages'][pkg_name] = False
         elif isinstance(packages, dict):
-            for pkg_name, pkg_opts in packages.items():
-                if isinstance(pkg_opts, dict):
-                    if 'ppa_source' in pkg_opts.keys():
-                        cleaned_dict['sources'].append(pkg_opts['ppa_source'])
-                    cleaned_dict['packages'][pkg_name] = pkg_opts.get('upgrade', False)
-                else:
-                    if pkg_opts:
-                        cleaned_dict['sources'].append(pkg_opts)
-                    cleaned_dict['packages'][pkg_name] = False
+                new_syntax = False
+            for key, value in packages.items():
+                if key == "packages" and isinstance(value, list):
+                    continue
+                if key == "sources" and isinstance(value, list):
+                    continue
+                if key == "update" and isinstance(value, bool):
+                    continue
+                break
+            else:
+                new_syntax = True
+            if new_syntax:
+                #new syntax, with different dicts for 
+                cleaned_dict["sources"] = packages.get("sources", dict())
+                for paket in packages.get("packages", list()):
+                    cleaned_dict["packages"][paket] = packages.get("update", False)
+            else:
+                #old syntax, with sources as package options
+                for pkg_name, pkg_opts in packages.items():
+                    if isinstance(pkg_opts, dict):
+                        if 'ppa_source' in pkg_opts.keys():
+                            cleaned_dict['sources'].append(pkg_opts['ppa_source'])
+                        cleaned_dict['packages'][pkg_name] = pkg_opts.get('upgrade', False)
+                    else:
+                        if pkg_opts:
+                            cleaned_dict['sources'].append(pkg_opts)
+                        cleaned_dict['packages'][pkg_name] = False
         return cleaned_dict
 
     def _add_ppa(self, source):


### PR DESCRIPTION
I found the part of the plugins yaml syntax irritating, in which the ppa is specified as an option for a specific package, since this does in no ways reflect, what is actually happening, e.g. all repos are cellected in a list and then added, while the packages are installed from which ever source a call to `apt install` would install them.

So I added an new type of syntax (without invalidating the old ones) which is less irritating in my opinion:
```
...
- aptget:
    packages:
        - package1
        - package2
        - ...
    sources:
        - repoString1
        - repoString2
        - ...
    update: False
```
As long as `aptget` is a dict, which only does contain some of the optional arguments `packages`, `sources` and `update`, the new syntax is used.
The `update` key is global for all packages default to `False`.