### PR TITLE
optimized and improved adding of sources

### DIFF
--- a/aptget.py
+++ b/aptget.py
@@ -93,6 +93,7 @@ class AptGet(dotbot.Plugin):
         mfull = rfull.fullmatch(source)
         if mppa is not None:
             sourcesList.add("deb", f"http://deb.launchpad.net/{mppa.group(1)}/{mppa.group(2)}/ubuntu", self._get_codename, ["main"], file=f"/etc/apt/sources.list.d/{mppa.group(1)}-{mppa.group(2)}.list")
+            sourcesList.add("deb-src", f"http://deb.launchpad.net/{mppa.group(1)}/{mppa.group(2)}/ubuntu", self._get_codename, ["main"], file=f"/etc/apt/sources.list.d/{mppa.group(1)}-{mppa.group(2)}.list", disabled=True)
             return True
         elif mfull is not None:
             if mfull.group('options') is None:


### PR DESCRIPTION
Using the sourceslist module from python-apt seems more efficient than calling `apt-add-repository` in a sub process.

`apt-add-repository` tends to update the cache automatically, every time, it has been run, which causes multiple updates, since this happens after adding *any* of the sources, and even if it already is in `sources.list.d`, which is very likely, since you usually don't have an extra source added, every time, you change your dotfiles. Not to mention, that the cache is updated anyway, after the plugin is done. handling the sources.

The plugin is now interpreting the string for the repo itself, checks for syntax errors (I'm pretty sure, my regex for that doesn't cover the weirdest cases imaginable, but I've never seen any really weird repo strings in the wild, so let's take care of that when it happens.) and  expands the strings for launchpad repos, since the python module doesn't to that itself.
What it doesn't do right now is, handling options in the repo string, since the module only can handle a fraction of them.